### PR TITLE
fix: OS-specific file paths

### DIFF
--- a/scripts/utils/docs/compileComponent.ts
+++ b/scripts/utils/docs/compileComponent.ts
@@ -29,8 +29,8 @@ export async function compileComponent({
 
   const component = parsed[0];
 
-  // Convert to local paths
-  component.filePath = relative(cwd(), filePath);
+  // Convert to local paths. Replacement normalizes path on Windows
+  component.filePath = relative(cwd(), filePath).replace("\\", "/");
 
   // Filter inherited HTML attributes
   for (const key in component.props) {


### PR DESCRIPTION
I was trying to regen the docs for react-resizable-panels and noticed that in the `public/generated/docs` directory, the JSON contained path separators which had changed as a result of regenerating.

e.g.

```
"filePath": "lib/components/panel/Panel.tsx",
```
changed to
```
"filePath": "lib\\components\\panel\\Panel.tsx",
```

This change fixes that, and the path will be the same regardless of platform. Windows supports both path separators.